### PR TITLE
Make the schedule non-alphabetized

### DIFF
--- a/eco_project/eco_project/schedule.py
+++ b/eco_project/eco_project/schedule.py
@@ -49,8 +49,37 @@ class RandomActivationByBreed(RandomActivation):
                       the next one.
         """
         if by_breed:
-            for agent_class in self.agents_by_breed:
-                self.step_breed(agent_class)
+            breeds_list = list(self.agents_by_breed.keys())
+            self.model.random.shuffle(breeds_list)
+            herbivores = [] # Holds the herbivore classes
+            carnivores = [] # Holds the carnivore classes
+            grass_class = None # Only one grass class
+            for agent_class in breeds_list:
+                if len(self.agents_by_breed[agent_class].keys()) <= 0:
+                    continue # Ignore extinct classes
+                else:
+                    sample = self.agents_by_breed[agent_class][list(self.agents_by_breed[agent_class].keys())[0]] # So we can access its tags
+                    if hasattr(sample, "tags"):
+                        if "carnivore" in sample.tags:
+                            carnivores.append(agent_class)
+                        elif "herbivore" in sample.tags:
+                            herbivores.append(agent_class)
+                        else:
+                            raise ValueError("Found an organism that's neither herbivore nor carnivore!")
+                    else:
+                        if grass_class is not None:
+                            raise ValueError("Found more than one class without tags!")
+                        else:
+                            grass_class = agent_class
+    
+            for herbivore_class in herbivores: # Herbivores move first, randomized
+                self.step_breed(herbivore_class)
+            for carnivore_class in carnivores: # Then carnivores
+                self.step_breed(carnivore_class)
+            self.step_breed(grass_class)       # Then grass grows
+
+            # Example of turns: (aardvark, zebra, wolf, tiger, grass); (zebra, aardvard, tiger, wolf, grass). Herbivores always get one and only one turn between each carnivore turn.
+
             self.steps += 1
             self.time += 1
         else:


### PR DESCRIPTION
The previous schedule had all the aardvarks move, then the tigers, then the wolves, then the zebras, the grass would grow, and the sequence would repeat. Under this system, aardvarks have a fairly large advantage over the zebras, as they have first pick right after the grass grows, and zebras can only get whatever the aardvarks don't eat. This is because the agents were activated alphabetically.

This introduces some randomness into the activations. Agents are still activated by class (all the aardvarks go at once), but aardvarks aren't guaranteed to go right after the grass goes. We can't completely randomize the classes because that'd mean a carnivore would sometimes move twice in a row with respect to a herbivore (not good!). I went for a compromise, having all the herbivore classes go in a random order, then having all the carnivore classes go in a random order, and then having the grass grow.

There is one downside to this activation sequence: Sometimes, zebras will move twice from the perspective of aardvarks, or vice versa. I don't see any good way to get rid of that without losing how all organisms of a class move at the same time.